### PR TITLE
Using assertInstanceOf assertion and allow_plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,10 @@
         "platform": {
             "php": "7.4"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     },
     "require": {
         "composer-plugin-api": "^1.1 || ^2.0"

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -93,16 +93,12 @@ namespace Infection\ExtensionInstaller\Tests {
 
         public function test_it_implements_plugin_interface(): void
         {
-            $plugin = new Plugin();
-
-            self::assertTrue(is_a($plugin, PluginInterface::class));
+            self::assertInstanceOf(PluginInterface::class, new Plugin());
         }
 
         public function test_it_implements_event_subscriber_interface(): void
         {
-            $plugin = new Plugin();
-
-            self::assertTrue(is_a($plugin, EventSubscriberInterface::class));
+            self::assertInstanceOf(EventSubscriberInterface::class, new Plugin());
         }
 
         public function test_it_subscribed_to_events(): void


### PR DESCRIPTION
# Changed log

- Using the `assertInstanceOf` to replace the `is_a` function to assert expected is same as result class instance.
- When running the `composer install` with the latest Composer version, it will present following error message:

```
In PluginManager.php line 738:

  phpstan/extension-installer contains a Composer plugin which is blocked by your allow-plugins config. Y
  ou may add it to the list if you consider it safe.
  You can run "composer config --no-plugins allow-plugins.phpstan/extension-installer [true|false]" to en
  able it (true) or disable it explicitly and suppress this exception (false)
  See https://getcomposer.org/allow-plugins


```

To resolve above error message, running the  `php ~/composer.phar config --no-plugins allow-plugins.phpstan/extension-installer true` to add the PHP dependency inside the `allow_plugin` config in the `composer.json` file.